### PR TITLE
Remove sequence number and domain from EventBatch

### DIFF
--- a/common/src/main/java/io/fluxcapacitor/common/api/eventsourcing/EventBatch.java
+++ b/common/src/main/java/io/fluxcapacitor/common/api/eventsourcing/EventBatch.java
@@ -24,15 +24,8 @@ import java.util.List;
 @Value
 public class EventBatch {
     String aggregateId;
-    String domain;
-    long lastSequenceNumber;
     List<SerializedMessage> events;
     boolean storeOnly;
-
-    @JsonIgnore
-    public Long getFirstSequenceNumber() {
-        return lastSequenceNumber - events.size() + 1;
-    }
 
     @JsonIgnore
     public boolean isEmpty() {
@@ -48,8 +41,6 @@ public class EventBatch {
     public String toString() {
         return "EventBatch{" +
                 "aggregateId='" + aggregateId + '\'' +
-                ", domain='" + domain + '\'' +
-                ", lastSequenceNumber=" + lastSequenceNumber +
                 ", event count=" + events.size() +
                 ", storeOnly=" + storeOnly +
                 '}';
@@ -57,16 +48,13 @@ public class EventBatch {
 
     @JsonIgnore
     public Metric toMetric() {
-        return Metric.builder().aggregateId(aggregateId).domain(domain)
-                .lastSequenceNumber(lastSequenceNumber).size(events.size()).storeOnly(storeOnly).build();
+        return Metric.builder().aggregateId(aggregateId).size(events.size()).storeOnly(storeOnly).build();
     }
 
     @Value
     @Builder
     public static class Metric {
         String aggregateId;
-        String domain;
-        long lastSequenceNumber;
         int size;
         boolean storeOnly;
     }

--- a/java-client/src/main/java/io/fluxcapacitor/javaclient/persisting/eventsourcing/AggregateEventStream.java
+++ b/java-client/src/main/java/io/fluxcapacitor/javaclient/persisting/eventsourcing/AggregateEventStream.java
@@ -29,11 +29,10 @@ public class AggregateEventStream<T> implements Stream<T> {
     @Delegate
     private final Stream<T> eventStream;
     private final String aggregateId;
-    private final String domain;
     private final Supplier<Long> lastSequenceNumber;
 
     public <O> AggregateEventStream<O> convert(Function<Stream<T>, Stream<O>> streamConvertor) {
-        return new AggregateEventStream<>(streamConvertor.apply(eventStream), aggregateId, domain, lastSequenceNumber);
+        return new AggregateEventStream<>(streamConvertor.apply(eventStream), aggregateId, lastSequenceNumber);
     }
 
     public Optional<Long> getLastSequenceNumber() {

--- a/java-client/src/main/java/io/fluxcapacitor/javaclient/persisting/eventsourcing/EventStore.java
+++ b/java-client/src/main/java/io/fluxcapacitor/javaclient/persisting/eventsourcing/EventStore.java
@@ -24,15 +24,15 @@ import static java.util.Arrays.asList;
 
 public interface EventStore extends HasLocalHandlers {
 
-    default Awaitable storeEvents(String aggregateId, String domain, long lastSequenceNumber, Object... events) {
-        return storeEvents(aggregateId, domain, lastSequenceNumber, asList(events));
+    default Awaitable storeEvents(String aggregateId, Object... events) {
+        return storeEvents(aggregateId, asList(events));
     }
 
-    default Awaitable storeEvents(String aggregateId, String domain, long lastSequenceNumber, List<?> events) {
-        return storeEvents(aggregateId, domain, lastSequenceNumber, events, false);
+    default Awaitable storeEvents(String aggregateId, List<?> events) {
+        return storeEvents(aggregateId, events, false);
     }
 
-    Awaitable storeEvents(String aggregateId, String domain, long lastSequenceNumber, List<?> events, boolean storeOnly);
+    Awaitable storeEvents(String aggregateId, List<?> events, boolean storeOnly);
 
     default AggregateEventStream<DeserializingMessage> getEvents(String aggregateId) {
         return getEvents(aggregateId, -1L);

--- a/java-client/src/main/java/io/fluxcapacitor/javaclient/persisting/eventsourcing/client/EventStoreClient.java
+++ b/java-client/src/main/java/io/fluxcapacitor/javaclient/persisting/eventsourcing/client/EventStoreClient.java
@@ -23,8 +23,7 @@ import java.util.concurrent.CompletableFuture;
 
 public interface EventStoreClient extends AutoCloseable {
 
-    Awaitable storeEvents(String aggregateId, String domain, long lastSequenceNumber, List<SerializedMessage> events,
-                          boolean storeOnly);
+    Awaitable storeEvents(String aggregateId, List<SerializedMessage> events, boolean storeOnly);
 
     default AggregateEventStream<SerializedMessage> getEvents(String aggregateId) {
         return getEvents(aggregateId, -1L);

--- a/java-client/src/main/java/io/fluxcapacitor/javaclient/persisting/repository/DefaultAggregateRepository.java
+++ b/java-client/src/main/java/io/fluxcapacitor/javaclient/persisting/repository/DefaultAggregateRepository.java
@@ -145,11 +145,12 @@ public class DefaultAggregateRepository implements AggregateRepository {
                                                     a -> ImmutableAggregateRoot.from(a, eventSourcingHandler,
                                                                                      serializer)))
                                                     .filter(a -> {
-                                                        boolean assignable = a.get() == null
+                                                        boolean assignable =
+                                                                a.get() == null
                                                                 || type.isAssignableFrom(a.get().getClass());
                                                         if (!assignable) {
                                                             log.warn("Could not load aggregate {} because the requested"
-                                                                             + " type {} is not assignable to the stored type {}",
+                                                                     + " type {} is not assignable to the stored type {}",
                                                                      id, type, a.get().getClass());
                                                         }
                                                         return assignable;
@@ -171,14 +172,13 @@ public class DefaultAggregateRepository implements AggregateRepository {
         }
 
         protected void commit(ImmutableAggregateRoot<?> model, List<DeserializingMessage> unpublishedEvents,
-                           String initialEventId) {
+                              String initialEventId) {
             try {
-                cache.<AggregateRoot<?>>compute(model.id(), (id, current) -> current == null
-                        || Objects.equals(initialEventId, current.lastEventId()) || unpublishedEvents.isEmpty()
-                        ? model : current.apply(unpublishedEvents));
+                cache.<AggregateRoot<?>>compute(model.id(), (id, current) ->
+                        current == null || Objects.equals(initialEventId, current.lastEventId())
+                        || unpublishedEvents.isEmpty() ? model : current.apply(unpublishedEvents));
                 if (!unpublishedEvents.isEmpty()) {
-                    eventStore.storeEvents(model.id(), collection, model.sequenceNumber(),
-                                           new ArrayList<>(unpublishedEvents)).awaitSilently();
+                    eventStore.storeEvents(model.id(), new ArrayList<>(unpublishedEvents)).awaitSilently();
                     if (snapshotTrigger.shouldCreateSnapshot(model, unpublishedEvents)) {
                         snapshotStore.storeSnapshot(model);
                     }

--- a/java-client/src/test/java/io/fluxcapacitor/javaclient/common/serialization/upcasting/GivenWhenThenUpcasterChainTest.java
+++ b/java-client/src/test/java/io/fluxcapacitor/javaclient/common/serialization/upcasting/GivenWhenThenUpcasterChainTest.java
@@ -46,7 +46,7 @@ public class GivenWhenThenUpcasterChainTest {
 
         @Test
         void testUpcastingWithDataInput() {
-            testFixture.givenDomainEvents(aggregateId, JsonUtils
+            testFixture.givenAppliedEvents(aggregateId, JsonUtils
                     .fromFile(this.getClass(), "create-model-revision-0.json", Object.class))
                     .whenQuery(new GetModel())
                     .expectResult(new TestModel(singletonList(new CreateModel("patchedContent"))));

--- a/java-client/src/test/java/io/fluxcapacitor/javaclient/givenwhenthen/GivenWhenThenTest.java
+++ b/java-client/src/test/java/io/fluxcapacitor/javaclient/givenwhenthen/GivenWhenThenTest.java
@@ -154,8 +154,8 @@ class GivenWhenThenTest {
     }
 
     @Test
-    void testGivenDomainEvents() {
-        subject.givenDomainEvents("test", new MockDomainEvent())
+    void testGivenAppliedEvents() {
+        subject.givenAppliedEvents("test", new MockAggregateEvent())
                 .whenApplying(fc -> loadAggregate("test", MockAggregate.class).get())
                 .expectResult(r -> r instanceof MockAggregate);
     }
@@ -211,12 +211,12 @@ class GivenWhenThenTest {
     @Aggregate
     private static class MockAggregate {
         @ApplyEvent
-        MockAggregate(MockDomainEvent event) {
+        MockAggregate(MockAggregateEvent event) {
         }
     }
 
     @Value
-    private static class MockDomainEvent {
+    private static class MockAggregateEvent {
     }
 
     @Value

--- a/java-client/src/test/java/io/fluxcapacitor/javaclient/persisting/eventsourcing/EventSourcingIntegrationTest.java
+++ b/java-client/src/test/java/io/fluxcapacitor/javaclient/persisting/eventsourcing/EventSourcingIntegrationTest.java
@@ -27,8 +27,6 @@ import org.junit.jupiter.api.Test;
 import static io.fluxcapacitor.javaclient.FluxCapacitor.loadAggregate;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atMost;
 import static org.mockito.Mockito.verify;
@@ -48,7 +46,7 @@ class EventSourcingIntegrationTest {
         assertEquals(4, testFixture.getFluxCapacitor().eventStore().getEvents("test").count());
 
         verify(testFixture.getFluxCapacitor().client().getEventStoreClient(), atMost(3))
-                .storeEvents(eq("test"), anyString(), anyLong(), anyList(), eq(false));
+                .storeEvents(eq("test"), anyList(), eq(false));
     }
 
     @Test

--- a/java-client/src/test/java/io/fluxcapacitor/javaclient/persisting/eventsourcing/EventSourcingRepositoryTest.java
+++ b/java-client/src/test/java/io/fluxcapacitor/javaclient/persisting/eventsourcing/EventSourcingRepositoryTest.java
@@ -111,7 +111,7 @@ class EventSourcingRepositoryTest {
         void testEventsGetStoredWhenHandlingEnds() {
             testFixture.givenNoPriorActivity().whenCommand(new CreateModel())
                     .expectThat(fc -> verify(eventStoreClient)
-                            .storeEvents(eq(aggregateId), eq(TestModel.class.getSimpleName()), eq(0L), anyList(),
+                            .storeEvents(eq(aggregateId), anyList(),
                                          eq(false)));
         }
 
@@ -129,7 +129,7 @@ class EventSourcingRepositoryTest {
                     .whenCommand(new ApplyNonsense())
                     .expectNoException()
                     .expectThat(fc -> verify(eventStoreClient)
-                            .storeEvents(eq(aggregateId), eq(TestModel.class.getSimpleName()), eq(1L), anyList(),
+                            .storeEvents(eq(aggregateId), anyList(),
                                          eq(false)));
         }
 
@@ -139,7 +139,7 @@ class EventSourcingRepositoryTest {
                     .whenCommand(new ApplyNonsense())
                     .expectException(HandlerNotFoundException.class)
                     .expectThat(fc -> verify(eventStoreClient, times(0))
-                            .storeEvents(anyString(), anyString(), anyLong(), anyList(), eq(false)));
+                            .storeEvents(anyString(), anyList(), eq(false)));
         }
 
         @SuppressWarnings("unchecked")
@@ -152,11 +152,11 @@ class EventSourcingRepositoryTest {
                             AggregateEventStream<SerializedMessage> result =
                                     (AggregateEventStream<SerializedMessage>) invocation.callRealMethod();
                             return new AggregateEventStream<>(result.getEventStream(), result.getAggregateId(),
-                                                              result.getDomain(), () -> 10L);
+                                                              () -> 10L);
                         });
                         fc.commandGateway().sendAndForget(new UpdateModel());
                     })
-                    .expectThat(fc -> verify(eventStoreClient).storeEvents(anyString(), anyString(), eq(11L), anyList(),
+                    .expectThat(fc -> verify(eventStoreClient).storeEvents(anyString(), anyList(),
                                                                            eq(false)));
         }
 
@@ -323,7 +323,7 @@ class EventSourcingRepositoryTest {
         void testCreateUsingFactoryMethod() {
             testFixture.givenNoPriorActivity().whenCommand(new CreateModel())
                     .expectThat(fc -> verify(testFixture.getFluxCapacitor().client().getEventStoreClient(), times(1))
-                            .storeEvents(anyString(), anyString(), anyLong(), anyList(), eq(false)));
+                            .storeEvents(anyString(), anyList(), eq(false)));
         }
 
         private class Handler {
@@ -352,7 +352,7 @@ class EventSourcingRepositoryTest {
 
             testFixture.givenNoPriorActivity().whenCommand(new CreateModel())
                     .expectThat(fc -> verify(testFixture.getFluxCapacitor().client().getEventStoreClient(), times(1))
-                            .storeEvents(anyString(), anyString(), anyLong(), anyList(), eq(false)));
+                            .storeEvents(anyString(), anyList(), eq(false)));
         }
 
         private class Handler {

--- a/java-client/src/test/java/io/fluxcapacitor/javaclient/persisting/eventsourcing/InMemoryEventStoreClientTest.java
+++ b/java-client/src/test/java/io/fluxcapacitor/javaclient/persisting/eventsourcing/InMemoryEventStoreClientTest.java
@@ -32,7 +32,7 @@ class InMemoryEventStoreClientTest {
     @Test
     void returnsCorrectStreamWhenLastSnIsMidBatch() throws Exception {
         List<SerializedMessage> in = createMessages(300);
-        subject.storeEvents("a", "test", in.size() - 1, in, false);
+        subject.storeEvents("a", in, false);
         Stream<SerializedMessage> out = subject.getEvents("a", 99L);
         assertEqualMessages(in.subList(100, 300), out.collect(Collectors.toList()));
     }

--- a/java-client/src/test/java/io/fluxcapacitor/javaclient/test/Given.java
+++ b/java-client/src/test/java/io/fluxcapacitor/javaclient/test/Given.java
@@ -34,7 +34,7 @@ public interface Given {
 
     When givenCommandsByUser(User user, Object... commands);
 
-    When givenDomainEvents(String aggregateId, Object... events);
+    When givenAppliedEvents(String aggregateId, Object... events);
 
     When givenEvents(Object... events);
 

--- a/java-client/src/test/java/io/fluxcapacitor/javaclient/test/When.java
+++ b/java-client/src/test/java/io/fluxcapacitor/javaclient/test/When.java
@@ -38,7 +38,7 @@ public interface When extends Given {
 
     Then whenEvent(Object event);
 
-    Then whenDomainEvents(String aggregateId, Object... events);
+    Then whenEventsAreApplied(String aggregateId, Object... events);
 
     Then whenSearching(String collection, UnaryOperator<Search> searchQuery);
 

--- a/java-client/src/test/java/io/fluxcapacitor/javaclient/tracking/StallingBatchInterceptorTest.java
+++ b/java-client/src/test/java/io/fluxcapacitor/javaclient/tracking/StallingBatchInterceptorTest.java
@@ -45,14 +45,14 @@ class StallingBatchInterceptorTest {
 
     @Test
     void testLargeBatchPassed() {
-        testFixture.whenDomainEvents("test", 0, 1)
+        testFixture.whenEventsAreApplied("test", 0, 1)
                 .expectThat(fc -> verify(handler, times(2)).handle(any()))
                 .expectThat(fc -> verify(fc.client().getTrackingClient(EVENT)).storePosition(any(), any(), anyLong()));
     }
 
     @Test
     void testSmallBatchStalled() {
-        testFixture.whenDomainEvents("test", 0)
+        testFixture.whenEventsAreApplied("test", 0)
                 .expectThat(fc -> verify(handler, never()).handle(any()))
                 .expectThat(fc -> verify(fc.client().getTrackingClient(EVENT), never())
                         .storePosition(any(), any(), anyLong()));
@@ -60,7 +60,7 @@ class StallingBatchInterceptorTest {
 
     @Test
     void testSmallBatchPassedAfterTimeout() {
-        testFixture.givenDomainEvents("test", 0)
+        testFixture.givenAppliedEvents("test", 0)
                 .whenTimeElapses(stallingDuration)
                 .expectThat(fc -> verify(handler, times(1)).handle(any()))
                 .expectThat(fc -> verify(fc.client().getTrackingClient(EVENT)).storePosition(any(), any(), anyLong()));

--- a/java-client/src/test/java/io/fluxcapacitor/javaclient/tracking/ThrowingErrorHandlerTest.java
+++ b/java-client/src/test/java/io/fluxcapacitor/javaclient/tracking/ThrowingErrorHandlerTest.java
@@ -38,14 +38,14 @@ class ThrowingErrorHandlerTest {
 
     @Test
     void testTrackingStoppedDuringFirstEvent() {
-        testFixture.whenDomainEvents("testAggregate", "error")
+        testFixture.whenEventsAreApplied("testAggregate", "error")
                 .expectThat(fc -> verify(fc.client().getTrackingClient(MessageType.EVENT), never())
                         .storePosition(any(), any(), anyLong()));
     }
 
     @Test
     void testTrackingStoppedDuringSecondEvent() {
-        testFixture.whenDomainEvents("testAggregate", 1, "error")
+        testFixture.whenEventsAreApplied("testAggregate", 1, "error")
                 .expectThat(fc -> {
                     TrackingClient trackingClient = fc.client().getTrackingClient(MessageType.EVENT);
                     verify(trackingClient).storePosition(any(), any(), eq((long) eventHandler.getFirstIndex()));

--- a/test-server/src/main/java/io/fluxcapacitor/testserver/endpoints/EventSourcingEndpoint.java
+++ b/test-server/src/main/java/io/fluxcapacitor/testserver/endpoints/EventSourcingEndpoint.java
@@ -42,7 +42,7 @@ public class EventSourcingEndpoint extends WebsocketEndpoint {
     @Handle
     public VoidResult handle(AppendEvents appendEvents) throws Exception {
         List<Awaitable> results = appendEvents.getEventBatches().stream().map(b -> eventStore
-                .storeEvents(b.getAggregateId(), b.getDomain(), b.getLastSequenceNumber(), b.getEvents(),
+                .storeEvents(b.getAggregateId(), b.getEvents(),
                              b.isStoreOnly())).collect(
                 Collectors.toList());
         for (Awaitable awaitable : results) {
@@ -63,7 +63,6 @@ public class EventSourcingEndpoint extends WebsocketEndpoint {
                 .getEvents(getEvents.getAggregateId(), getEvents.getLastSequenceNumber());
         long lastSequenceNumber = stream.getLastSequenceNumber().orElse(-1L);
         return new GetEventsResult(getEvents.getRequestId(), new EventBatch(
-                getEvents.getAggregateId(), stream.getDomain(), lastSequenceNumber,
-                stream.collect(Collectors.toList()), false), lastSequenceNumber);
+                getEvents.getAggregateId(), stream.collect(Collectors.toList()), false), lastSequenceNumber);
     }
 }


### PR DESCRIPTION
Makes it easy to have multiple writers for one aggregate.